### PR TITLE
Add Windows support to install

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -3,7 +3,7 @@ module.exports = installHooks;
 var fs = require('fs');
 var cwd = process.cwd();
 var resolve = require('path').resolve;
-var projectRoot = resolve(cwd.replace(/node_modules\/.*/, ''));
+var projectRoot = resolve(cwd.replace(/node_modules\/.*|node_modules\\.*/, ''));
 var hooksDir = resolve(projectRoot, '.git/hooks');
 var template = require('./hook.template');
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 
   "scripts"              : {
     "test"               : "make test",
-    "install"            : "./bin/install"
+    "install"            : "node ./bin/install"
   },
 
   "dependencies"         : {


### PR DESCRIPTION
This pull request updates the install action in the package.json and the project root search in the install script so that it's more friendly with Windows.

Tested on OS X Yosemite and WIndows 7.