### PR TITLE
Settings projectRoot to parent projects folder

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -3,7 +3,13 @@ module.exports = installHooks;
 var fs = require('fs');
 var cwd = process.cwd();
 var resolve = require('path').resolve;
-var projectRoot = resolve(cwd, '..', '..');
+var projectRoot;
+
+if(cwd.match(/node_modules/g) > 1)
+  projectRoot = resolve(cwd, '..', '..');
+else
+  projectRoot = resolve(cwd.replace(/node_modules\/.*|node_modules\\.*/, ''));
+
 var hooksDir = resolve(projectRoot, '.git/hooks');
 var template = require('./hook.template');
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,7 +3,7 @@ module.exports = installHooks;
 var fs = require('fs');
 var cwd = process.cwd();
 var resolve = require('path').resolve;
-var projectRoot = resolve(cwd.replace(/node_modules\/.*|node_modules\\.*/, ''));
+var projectRoot = resolve(cwd, '..', '..');
 var hooksDir = resolve(projectRoot, '.git/hooks');
 var template = require('./hook.template');
 


### PR DESCRIPTION
Maybe I have missed something here but I think the projectRoot should be set to the parent project folder. The problem we have is that we have a sub lib to our main app that is dependent on ghooks. When we run npm install from our main project ghooks installs the hooks in that project causing it to fail during commits due to the fact that ghooks is not installed in that project. Do you get it =)
And the way projectRoot now is set this is by design.