### PR TITLE
Remove arg from `commit-msg` sample hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Add a `config.ghooks` entry in your `package.json` and simply specify which git 
   "config": {
     "ghooks": {
       "pre-commit": "gulp lint",
-      "commit-msg": "validate-commit-msg $1",
+      "commit-msg": "validate-commit-msg",
       "pre-push": "make test",
       "post-merge": "npm install",
       "post-rewrite": "npm install",


### PR DESCRIPTION
I was just setting this up in my repo and `$1` was causing problems with `validate-commit-msg`. It would always fail and then add `#!/usr/bin/env node` to the *end* of `.git/hooks/commit-msg` making the hook unable to run from that point on.

I tested a positive and negative case without `$1`. It allows the commit with a valid message and disallows the commit with an invalid message.