### PR TITLE
Use findup to traverse tree for .git, package.json

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,8 +4,8 @@
   "camelcase"     : true,
   "maxparams"     : 3,
   "maxdepth"      : 3,
-  "maxstatements" : 5,
-  "maxcomplexity" : 2,
+  "maxstatements" : 6,
+  "maxcomplexity" : 3,
   "maxlen"        : 80,
 
   "asi"           : false,

--- a/lib/install.js
+++ b/lib/install.js
@@ -3,9 +3,7 @@ module.exports = installHooks;
 var fs = require('fs');
 var cwd = process.cwd();
 var resolve = require('path').resolve;
-var projectRoot = cwd.replace(/node_modules(?!.*node_modules(\/|\\|$)).*/, '');
-projectRoot = resolve(projectRoot);
-var hooksDir = resolve(projectRoot, '.git/hooks');
+var findup = require('findup');
 var template = require('./hook.template');
 
 var hooks = [
@@ -28,16 +26,22 @@ var hooks = [
   'post-rewrite',
 ];
 
-function installHooks () {
-  if (isGitProject()) {
-    ensureHooksDirExists();
-    hooks.forEach(install);
+function findGitRoot (directory) {
+  try {
+    return findup.sync(directory || cwd, '.git');
+  } catch(e) {
+    return null;
   }
-  else { warnAboutGit(); }
 }
 
-function isGitProject () {
-  return fs.existsSync(resolve(projectRoot, '.git'));
+function installHooks (directory) {
+  var gitRoot = findGitRoot(directory);
+  if (gitRoot) {
+    var hooksDir = resolve(gitRoot, '.git/hooks');
+    ensureHooksDirExists(hooksDir);
+    hooks.forEach(install.bind(null, hooksDir));
+  }
+  else { warnAboutGit(); }
 }
 
 function warnAboutGit () { console.warn(
@@ -47,8 +51,8 @@ function warnAboutGit () { console.warn(
   'Please ignore this message if you are not using ghooks directly.'
 );}
 
-function install(hook) {
-  var file = hookFile(hook);
+function install(hooksDir, hook) {
+  var file = hookFile(hooksDir, hook);
   if (needsBackup(file)) { backup(file); }
   fs.writeFileSync(file, template.content);
   fs.chmodSync(file, '755');
@@ -66,10 +70,10 @@ function backup (file) {
   fs.renameSync(file, file + '.bkp');
 }
 
-function hookFile (name) {
+function hookFile (hooksDir, name) {
   return resolve(hooksDir, name);
 }
 
-function ensureHooksDirExists () {
+function ensureHooksDirExists (hooksDir) {
   if (!fs.existsSync(hooksDir)) { fs.mkdirSync(hooksDir); }
 }

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -2,6 +2,8 @@ var clone = require('lodash.clone');
 var managePath = require('manage-path');
 var spawn = require('spawn-command');
 var resolve = require('path').resolve;
+var findup = require('findup');
+var fs = require('fs');
 
 module.exports = function run (dirname, filename, env) {
   var restorePath;
@@ -14,10 +16,10 @@ function hook (dirname, filename) {
 }
 
 function commandFor (hook) {
-  var pkg = require(resolve(process.cwd(), 'package'));
+  var pkgFile = findup.sync(process.cwd(), 'package.json');
+  var pkg = JSON.parse(fs.readFileSync(resolve(pkgFile, 'package.json')));
   if (pkg.config && pkg.config.ghooks && pkg.config.ghooks[hook]) {
     var command = pkg.config.ghooks[hook];
-
     // replace any instance of $1 or $2 etc. to that item as an process.argv
     return command.replace(/\$(\d)/g, function(match, number) {
       return process.argv[number];

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "install": "node ./bin/install"
   },
   "dependencies": {
+    "findup": "^0.1.5",
     "lodash.clone": "3.0.3",
     "manage-path": "2.0.0",
     "spawn-command": "^0.0.2"


### PR DESCRIPTION
Fixes #35, #28, #3. Closes #36

This uses the [findup] package to traverse up the directory tree of
the current working directory, to find `package.json`, or `.git`.
It does so to allow for edge-case situations, such as described in
and #35 (executing hooks from a different working dir, for example
with `git --work-tree`).

As part of this commit, the JSHint maxcomplexity/maxstatements
numbers have been bumped by 1.

[findup]: https://www.npmjs.com/package/findup

---

Note: I think #36 (/cc @gtramontina) should be closed as the functionality in this PR overlaps that of #36.