### PR TITLE
chore(travis): fix matrix build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - npm run check-coverage
 after_success:
   - npm run report-coverage
-  - npm run semantic-release
+  - travis-after-all && npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "semantic-release": "^4.3.5",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.7.0",
+    "travis-after-all": "^1.4.4",
     "validate-commit-msg": "1.0.0"
   },
   "config": {


### PR DESCRIPTION
@kentcdodds :wave: 

Semantic release is failing to publish to npm properly because matrix
builds inside travis cause a race condition in npm publish. travis
executes the npm publish step at the same time and therefore npm
screws up the publish.

This adds travis-after-all which prevents the sidecar builds from
publishing, and the main build waits until the sidecar builds have
passed before publishing.

I've implemented this before (see [this package.json](https://github.com/packagesmith/provision-npm-babel/blob/master/package.json#L59), [this travis.yml](https://github.com/packagesmith/provision-npm-babel/blob/master/.travis.yml#L11) and [this example build job](https://travis-ci.org/packagesmith/provision-npm-babel/jobs/100317363) if you want to see it in action).