### PR TITLE
Add opt-in functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 coverage
 .idea
+.opt-in
+.opt-out
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 Thanks for your interest in contributing! Here's a few things to keep in mind when contributing to this project:
 
+This project uses `ghooks` to run `commit-msg` and `pre-commit` hooks.
+
+These hooks are `opt-in` only, so if you want to run them (recommended) then add an `.opt-in` file to the root of the project:
+
+```
+pre-commit
+commit-msg
+```
+
+We do this to make it easier for new comers to contribute and allow experienced contributors avoid pushing stuff that'll break the build.
+
 ## semantic-release
 
 We use [semantic-release](http://npm.im/semantic-release) to manage releases. This means we have a convention for our commit messages.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npm install ghooks --save-dev
 _It is not advised to install `ghooks` as a production dependency, as it will install git hooks in your production environment as well. Please install it under the `devDependencies` section of your `package.json`._
 
 ## Setup
+
 Add a `config.ghooks` entry in your `package.json` and simply specify which git hooks you want and their corresponding commands, like the following:
 
 ```
@@ -41,6 +42,10 @@ Add a `config.ghooks` entry in your `package.json` and simply specify which git 
   …
 }
 ```
+
+## opt-in/out
+
+One of the last things you want is to raise the barrier to contributing to your open source project. So [Andreas Windt](https://github.com/ta2edchimp) developed the [opt-cli](https://npmjs.com/package/opt-cli) package to allow you to turn your hooks into opt-in/out scripts. See this project's [`package.json`](package.json) for an example of how to do that.
 
 ## All [documented](http://git-scm.com/docs/githooks) hooks are available:
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "coverage": "istanbul cover -i lib/**/*.js _mocha -- test/**/*.test.js",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
+    "validate": "npm t && npm run check-coverage",
     "commit": "git-cz",
     "install": "node ./bin/install",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
@@ -47,6 +48,7 @@
     "jshint-stylish": "^2.0.0",
     "mocha": "^2.1.0",
     "mock-fs": "^3.0.0",
+    "opt-cli": "1.1.1",
     "proxyquire": "^1.3.1",
     "semantic-release": "^4.3.5",
     "sinon": "^1.12.2",
@@ -56,8 +58,8 @@
   },
   "config": {
     "ghooks": {
-      "pre-commit": "npm test && npm run check-coverage",
-      "commit-msg": "validate-commit-msg"
+      "pre-commit": "opt --in pre-commit --exec \"npm run validate\"",
+      "commit-msg": "opt --in commit-msg --exec validate-commit-msg"
     },
     "commitizen": {
       "path": "node_modules/cz-conventional-changelog"


### PR DESCRIPTION
Do not merge yet...

This is to add @ta2edchimp's awesome new [opt-in](https://github.com/ta2edchimp/opt-cli) package.

There are, however a few issues with `opt-in` we need resolved before this can be merged. Will file them soon.

1. The output is not streamed to the stdout/err which means you see no output until it's done (if it ever finishes). The cli package that's being used evidently isn't setting `stdio: 'inherit'` as it should (like [this](https://github.com/gtramontina/ghooks/blob/5ac56bf5869cc1dd69db6dad83ae6cbcf1dac0aa/lib/runner.js#L34)).
2. I think that the command is not executed with the proper `$PATH` because I don't think that it can find `validate-commit-msg` which is in `node_modules/.bin/` which [we add](https://github.com/gtramontina/ghooks/blob/5ac56bf5869cc1dd69db6dad83ae6cbcf1dac0aa/lib/runner.js#L31-L33) to the path when [we run our scripts](https://github.com/gtramontina/ghooks/blob/5ac56bf5869cc1dd69db6dad83ae6cbcf1dac0aa/lib/runner.js#L34)