### PR TITLE
Complete code style adjustion

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
-var install = require('../lib/install');
-install();
+const install = require('../lib/install')
+install()

--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 // {{generated_message}}
 
-(function () {
-  try { require('ghooks'); }
-  catch (e) { return warnAboutGHooks(); }
-  require('ghooks')(__dirname, __filename);
-})();
+(function hookEntryPoint() {
+  try {
+    require('ghooks')
+  } catch (e) {
+    return warnAboutGHooks()
+  }
+  require('ghooks')(__dirname, __filename)
+})()
 
-function warnAboutGHooks () { console.warn(
-  'ghooks not found!\n' +
-  'Make sure you have it installed on your "node_modules".\n' +
-  'Skipping git hooks.'
-);}
+function warnAboutGHooks() {
+  console.warn( // eslint-disable-line no-console
+    'ghooks not found!\n' +
+    'Make sure you have it installed on your "node_modules".\n' +
+    'Skipping git hooks.'
+  )
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/gtramontina/ghooks/issues"
   },
   "scripts": {
-    "lint": "eslint bin/ lib/ test/",
+    "lint": "eslint bin/* lib/* test/",
     "test:unit": "mocha --compilers js:babel-register",
     "test": "npm run lint && npm run coverage",
     "coverage": "istanbul cover -i lib/**/*.js _mocha -- --compilers js:babel-register test/**/*.test.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "spawn-command": "0.0.2"
   },
   "devDependencies": {
-    "babel-cli": "6.6.5",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.4.3",
     "chai": "^3.0.0",


### PR DESCRIPTION
- Removed `babel-cli` as a dependency, as it became unnecessary with cb5187a.
- Completed the code adjustments (include `lib/hook.template.raw` into linting process).

To complement #43 