### PR TITLE
Fix: Build package prior to installing

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "validate": "npm t && npm run check-coverage",
     "commit": "git-cz",
-    "install": "opt --out ghooks-install --exec \"node ./bin/install\"",
+    "install": "opt --out ghooks-install --exec \"[ ! -d \"./dist\" ] && npm run build; node ./bin/install\"",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {


### PR DESCRIPTION
The `install` script has been adjusted to invoke `npm run build` on `install` if the `dist` dir is not present (that is, when fetching from git or sth like that).

**Note for Windows**
I have no idea if this solution would suffice in Windows environments. I guess the script will fail due to the default command line (`cmd.exe`) not recognizing the statement. Any ideas?
