### PR TITLE
Follow up to #50: Exit with error if ghooks is not found

### DIFF
--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -5,7 +5,8 @@
   try {
     require('ghooks')
   } catch (e) {
-    return warnAboutGHooks()
+    warnAboutGHooks()
+    process.exit(1)
   }
   require('ghooks')(__dirname, __filename)
 })()

--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -20,8 +20,19 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
   describe('when ghooks is not found', () => {
     it('warns about ghooks not being present', sinon.test(function test() {
       const warn = this.stub(console, 'warn')
-      proxyquire('../lib/hook.template.raw', {ghooks: null})
+      const exitMessage = 'Exit process when ghooks not being present'
+      // instead of really exiting the process ...
+      const exit = this.stub(process, 'exit', () => {
+        // ... throw a predetermined exception, thus preventing
+        // further code execution within the tested module ...
+        throw Error(exitMessage)
+      })
+      // ... and expect it to be eventually thrown
+      expect(() => {
+        proxyquire('../lib/hook.template.raw', {ghooks: null})
+      }).to.throw(exitMessage)
       expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
+      expect(exit).to.have.been.calledWith(1)
     }))
 
   })


### PR DESCRIPTION
- Adjusted test to take into account that the hooks' scripts now return with an error if ghooks couldn't be found.
- Adjusted original commit message to comply with conventions.