### PR TITLE
Build package prior to installing

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,3 +1,23 @@
 #!/usr/bin/env node
-const install = require('../dist/install')
-install()
+const exists = require('path-exists')
+const exec = require('execa')
+
+function isBuilt() {
+  return exists('./dist')
+}
+
+function build() {
+  return exec('npm', ['run', 'build'])
+}
+
+function install() {
+  require('../dist/install')()
+}
+
+isBuilt().then(function built(yes) {
+  if (yes) {
+    install()
+  } else {
+    build().then(install)
+  }
+})

--- a/package.json
+++ b/package.json
@@ -29,14 +29,16 @@
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "validate": "npm t && npm run check-coverage",
     "commit": "git-cz",
-    "install": "opt --out ghooks-install --exec \"[ ! -d \"./dist\" ] && npm run build; node ./bin/install\"",
+    "install": "opt --out ghooks-install --exec \"node ./bin/install\"",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {
+    "execa": "^0.2.2",
     "findup": "0.1.5",
     "lodash.clone": "4.3.2",
     "manage-path": "2.0.0",
     "opt-cli": "1.4.0",
+    "path-exists": "^2.1.0",
     "spawn-command": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Using node to check whether running `npm run build` is required.

Closes #63 

---

I was looking for something like `path-exists` but with a CLI. This way we could simply replace `[ ! -d \"./dist\" ] && …` with `pathExits "./dist" || …`. Then we could also get rid of `execa`.

*Maybe I'll submit `path-exists` a PR :thought_balloon:*