### PR TITLE
Support submodules & worktrees

### DIFF
--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -3,12 +3,10 @@
 
 const fs = require('fs')
 const path = require('path')
+const ghooks = getGhooksEntryPoint()
 
-;(function hookEntryPoint() {
-  const ghooks = getGhooksEntryPoint()
-  checkForGHooks(ghooks)
-  require(ghooks)(__dirname, __filename)
-})()
+checkForGHooks(ghooks)
+require(ghooks)(__dirname, __filename)
 
 function getGhooksEntryPoint() {
   const worktree = getWorkTree()
@@ -18,9 +16,9 @@ function getGhooksEntryPoint() {
   return 'ghooks'
 }
 
-function checkForGHooks(ghooks) {
+function checkForGHooks(ghooksPath) {
   try {
-    require(ghooks)
+    require(ghooksPath)
   } catch (e) {
     warnAboutGHooks()
     process.exit(1)
@@ -31,7 +29,7 @@ function getWorkTree() {
   try {
     return getWorkTreeFromConfig(getConfigFileContent())
   } catch (e) {
-    return ''
+    return null
   }
 }
 

--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -1,15 +1,53 @@
 #!/usr/bin/env node
 // {{generated_message}}
 
-(function hookEntryPoint() {
+const fs = require('fs')
+const path = require('path')
+
+;(function hookEntryPoint() {
+  const ghooks = getGhooksEntryPoint()
+  checkForGHooks(ghooks)
+  require(ghooks)(__dirname, __filename)
+})()
+
+function getGhooksEntryPoint() {
+  const worktree = getWorkTree()
+  if (worktree) {
+    return path.resolve(__dirname, '../', worktree, 'node_modules', 'ghooks')
+  }
+  return 'ghooks'
+}
+
+function checkForGHooks(ghooks) {
   try {
-    require('ghooks')
+    require(ghooks)
   } catch (e) {
     warnAboutGHooks()
     process.exit(1)
   }
-  require('ghooks')(__dirname, __filename)
-})()
+}
+
+function getWorkTree() {
+  try {
+    return getWorkTreeFromConfig(getConfigFileContent())
+  } catch (e) {
+    return ''
+  }
+}
+
+function getConfigFileContent() {
+  const configFile = path.resolve(__dirname, '../config')
+  const fileStat = fs.statSync(configFile)
+  if (fileStat && fileStat.isFile()) {
+    return fs.readFileSync(configFile, 'utf8')
+  }
+  return ''
+}
+
+function getWorkTreeFromConfig(configFileContent) {
+  const worktreeRegEx = /\[core\][^]{0,}worktree = ([^\n]{1,})[^]{0,}/
+  return worktreeRegEx.test(configFileContent) ? configFileContent.replace(worktreeRegEx, '$1') : ''
+}
 
 function warnAboutGHooks() {
   console.warn( // eslint-disable-line no-console

--- a/lib/install.js
+++ b/lib/install.js
@@ -26,7 +26,7 @@ const hooks = [
 function installHooks() {
   const gitRoot = findGitRoot()
   if (gitRoot) {
-    const hooksDir = resolve(gitRoot, '.git/hooks')
+    const hooksDir = resolve(gitRoot, 'hooks')
     hooks.forEach(install.bind(null, hooksDir))
   } else {
     warnAboutGit()
@@ -35,10 +35,34 @@ function installHooks() {
 
 function findGitRoot() {
   try {
-    return findup.sync(process.cwd(), '.git')
+    return getGitRoot()
   } catch (e) {
     return null
   }
+}
+
+function getGitRoot() {
+  const gitRoot = findup.sync(process.cwd(), '.git')
+  const gitPath = resolve(gitRoot, '.git')
+  const fileStat = fs.statSync(gitPath)
+  return gitPathDir(gitPath, fileStat) || gitPathFile(gitPath, fileStat, gitRoot)
+}
+
+function gitPathDir(gitPath, fileStat) {
+  return fileStat.isDirectory() ? gitPath : null
+}
+
+function gitPathFile(gitPath, fileStat, gitRoot) {
+  return fileStat.isFile() ? parseGitFile(fileStat, gitPath, gitRoot) : null
+}
+
+function parseGitFile(fileStat, gitPath, gitRoot) {
+  const gitDirRegex = /[^]{0,}gitdir: ([^\n]{1,})[^]{0,}/
+  const gitFileContents = fs.readFileSync(gitPath, 'utf8')
+  if (gitDirRegex.test(gitFileContents)) {
+    return resolve(gitRoot, gitFileContents.replace(gitDirRegex, '$1'))
+  }
+  return null
 }
 
 function warnAboutGit() {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint bin/* lib/* test/",
     "test:unit": "mocha --compilers js:babel-register",
     "test": "npm run lint && npm run coverage",
-    "coverage": "istanbul cover -i lib/**/*.js _mocha -- --compilers js:babel-register test/**/*.test.js",
+    "coverage": "istanbul cover -i lib/**/* _mocha -- --compilers js:babel-register test/**/*.test.js",
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "validate": "npm t && npm run check-coverage",

--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -37,4 +37,111 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
 
   })
 
+  describe('when ghooks is installed, using worktree / in a submodule', () => {
+
+    beforeEach(() => {
+      const path = require('path')
+      const worktree = '../../a/path/somewhere/else'
+      const ghooksResolved = path.resolve(process.cwd(), worktree, 'node_modules', 'ghooks')
+      const stub = {
+        fs: {
+          statSync: () => {
+            return {isFile: () => true}
+          },
+          readFileSync: () => '[core]\n\tworktree = ' + worktree,
+        },
+      }
+      stub[ghooksResolved] = this.ghooks = sinon.stub()
+      proxyquire('../lib/hook.template.raw', stub)
+    })
+
+    it('delegates the hook execution to ghooks', () => {
+      const dirname = process.cwd() + '/lib'
+      const filename = dirname + '/hook.template.raw'
+      expect(this.ghooks).to.have.been.calledWith(dirname, filename)
+    })
+
+  })
+
+  describe('when ghooks is not found, using worktree / in a submodule', () => {
+
+    it('warns about ghooks not being found in gitdir', sinon.test(function test() {
+      const stub = {
+        ghooks: null,
+        fs: {
+          statSync: () => {
+            return {isFile: () => true}
+          },
+          readFileSync: () => '[core]\n\tworktree = ../../a/path/somewhere/else',
+        },
+      }
+      const warn = this.stub(console, 'warn')
+      const exitMessage = 'Exit process when ghooks not being present'
+      // instead of really exiting the process ...
+      const exit = this.stub(process, 'exit', () => {
+        // ... throw a predetermined exception, thus preventing
+        // further code execution within the tested module ...
+        throw Error(exitMessage)
+      })
+      // ... and expect it to be eventually thrown
+      expect(() => {
+        proxyquire('../lib/hook.template.raw', stub)
+      }).to.throw(exitMessage)
+      expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
+      expect(exit).to.have.been.calledWith(1)
+    }))
+
+    it('warns about ghooks not being found due to no gitdir being present', sinon.test(function test() {
+      const stub = {
+        ghooks: null,
+        fs: {
+          statSync: () => {
+            return {isFile: () => true}
+          },
+          readFileSync: () => '[anything]\n\tsomething = else',
+        },
+      }
+      const warn = this.stub(console, 'warn')
+      const exitMessage = 'Exit process when ghooks not being present'
+      // instead of really exiting the process ...
+      const exit = this.stub(process, 'exit', () => {
+        // ... throw a predetermined exception, thus preventing
+        // further code execution within the tested module ...
+        throw Error(exitMessage)
+      })
+      // ... and expect it to be eventually thrown
+      expect(() => {
+        proxyquire('../lib/hook.template.raw', stub)
+      }).to.throw(exitMessage)
+      expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
+      expect(exit).to.have.been.calledWith(1)
+    }))
+
+    it('warns about ghooks not being found due to no valid git config being present', sinon.test(function test() {
+      const stub = {
+        ghooks: null,
+        fs: {
+          statSync: () => {
+            return {isFile: () => false}
+          },
+        },
+      }
+      const warn = this.stub(console, 'warn')
+      const exitMessage = 'Exit process when ghooks not being present'
+      // instead of really exiting the process ...
+      const exit = this.stub(process, 'exit', () => {
+        // ... throw a predetermined exception, thus preventing
+        // further code execution within the tested module ...
+        throw Error(exitMessage)
+      })
+      // ... and expect it to be eventually thrown
+      expect(() => {
+        proxyquire('../lib/hook.template.raw', stub)
+      }).to.throw(exitMessage)
+      expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
+      expect(exit).to.have.been.calledWith(1)
+    }))
+
+  })
+
 })

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -79,6 +79,27 @@ describe('install', function describeInstall() {
 
 })
 
+describe('install using worktree / as a submodule', function describeInstall() {
+  const install = require('../lib/install')
+
+  it('warns when no gitdir specified for worktree / submodule', sinon.test(function test() {
+    fsStub({'.git': ''})
+    const warn = this.stub(console, 'warn')
+    install()
+    expect(warn).to.have.been.calledWithMatch(/this does not seem to be a git project/i)
+  }))
+
+  it('creates hooks directory using gitdir', () => {
+    fsStub({
+      '.git': 'gitdir: ../../a/path/somewhere/else',
+      '../../a/path/somewhere/else': {},
+    })
+    install()
+    expect(fs.existsSync('../../a/path/somewhere/else/hooks')).to.be.true
+  })
+
+})
+
 function fileMode(file) {
   const allOn = 4095 // == 07777 (octal)
   return (fs.statSync(file).mode & allOn) // eslint-disable-line no-bitwise

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -100,6 +100,26 @@ describe('install using worktree / as a submodule', function describeInstall() {
 
 })
 
+describe('install (ensure 100% code coverage)', function describeInstall() {
+  const install = require('proxyquire')('../lib/install', {
+    fs: {
+      statSync() {
+        // to provoke the case where a '.git' entry on the filesystem
+        // is neither a directory nor a file
+        return {isDirectory: () => false, isFile: () => false}
+      },
+    },
+  })
+
+  it('warns when no gitdir specified for worktree / submodule', sinon.test(function test() {
+    const warn = this.stub(console, 'warn')
+    fsStub({'.git': ''})
+    install()
+    expect(warn).to.have.been.calledWithMatch(/this does not seem to be a git project/i)
+  }))
+
+})
+
 function fileMode(file) {
   const allOn = 4095 // == 07777 (octal)
   return (fs.statSync(file).mode & allOn) // eslint-disable-line no-bitwise


### PR DESCRIPTION
At the moment, this PR is rather a proof and is more for the purpose to get feedback early on, as well as to keep track of the progress (and of the key ideas for me to remember when getting back on this after I had some sleep).
When finished, this PR will address the issue #46 and probably #66 too, as their key difference to a usual git repo is identical.

In current versions of git, submodules don't have a `.git` folder in their root directory (and therefore, no `.git/hooks` folder too). Instead, they have a config **file** called `.git`, with something like the following content:

```
gitdir: ../.git/modules/submod-1
```

So this is basically the pointer towards where the submodule's `hooks` directory will reside. Accordingly, I altered ghooks' `./lib/install.js` to take this into account.

On the other hand, the hooks themselves must also take their location — relative to where the package's `node_modules` directory (and therefore the `ghooks` dependency) resides — into account.
My first approach was to inject a path into the hooks' scripts upon installation, but I that felt really dirty, so I decided to take advantage of their location on the filesystem: One level upwards, will _always_ reside a `config` file for the particular repo, containing a `worktree` setting describing where (relative to the superproject root) the submodule is located. The hooks scripts try to obtain this setting and will require the `ghooks` dependency accordingly.

### This PR still lacks

- [x] Clean code according to the set up linting rules.
- [x] Thorough unit tests.

### Questions

1. Is there a way to make beta versions available while using `semantic-release`?
I'd really like to get this tested as a real „non-RTM“ npm package by some brave users :wink: (`npm link`ing or fetching directly from a git branch simply don't suffice).