### PR TITLE
fix: Don't exit with non-zero code on error

### DIFF
--- a/lib/hook.template.raw
+++ b/lib/hook.template.raw
@@ -5,8 +5,9 @@ const fs = require('fs')
 const path = require('path')
 const ghooks = getGhooksEntryPoint()
 
-checkForGHooks(ghooks)
-require(ghooks)(__dirname, __filename)
+if (checkForGHooks(ghooks)) {
+  require(ghooks)(__dirname, __filename)
+}
 
 function getGhooksEntryPoint() {
   const worktree = getWorkTree()
@@ -21,8 +22,9 @@ function checkForGHooks(ghooksPath) {
     require(ghooksPath)
   } catch (e) {
     warnAboutGHooks()
-    process.exit(1)
+    return false
   }
+  return true
 }
 
 function getWorkTree() {

--- a/test/hook.template.raw.test.js
+++ b/test/hook.template.raw.test.js
@@ -20,19 +20,8 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
   describe('when ghooks is not found', () => {
     it('warns about ghooks not being present', sinon.test(function test() {
       const warn = this.stub(console, 'warn')
-      const exitMessage = 'Exit process when ghooks not being present'
-      // instead of really exiting the process ...
-      const exit = this.stub(process, 'exit', () => {
-        // ... throw a predetermined exception, thus preventing
-        // further code execution within the tested module ...
-        throw Error(exitMessage)
-      })
-      // ... and expect it to be eventually thrown
-      expect(() => {
-        proxyquire('../lib/hook.template.raw', {ghooks: null})
-      }).to.throw(exitMessage)
+      proxyquire('../lib/hook.template.raw', {ghooks: null})
       expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
-      expect(exit).to.have.been.calledWith(1)
     }))
 
   })
@@ -76,19 +65,8 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
         },
       }
       const warn = this.stub(console, 'warn')
-      const exitMessage = 'Exit process when ghooks not being present'
-      // instead of really exiting the process ...
-      const exit = this.stub(process, 'exit', () => {
-        // ... throw a predetermined exception, thus preventing
-        // further code execution within the tested module ...
-        throw Error(exitMessage)
-      })
-      // ... and expect it to be eventually thrown
-      expect(() => {
-        proxyquire('../lib/hook.template.raw', stub)
-      }).to.throw(exitMessage)
+      proxyquire('../lib/hook.template.raw', stub)
       expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
-      expect(exit).to.have.been.calledWith(1)
     }))
 
     it('warns about ghooks not being found due to no gitdir being present', sinon.test(function test() {
@@ -102,19 +80,8 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
         },
       }
       const warn = this.stub(console, 'warn')
-      const exitMessage = 'Exit process when ghooks not being present'
-      // instead of really exiting the process ...
-      const exit = this.stub(process, 'exit', () => {
-        // ... throw a predetermined exception, thus preventing
-        // further code execution within the tested module ...
-        throw Error(exitMessage)
-      })
-      // ... and expect it to be eventually thrown
-      expect(() => {
-        proxyquire('../lib/hook.template.raw', stub)
-      }).to.throw(exitMessage)
+      proxyquire('../lib/hook.template.raw', stub)
       expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
-      expect(exit).to.have.been.calledWith(1)
     }))
 
     it('warns about ghooks not being found due to no valid git config being present', sinon.test(function test() {
@@ -127,19 +94,8 @@ describe('hook.template.raw', function describeHookTemplateRaw() {
         },
       }
       const warn = this.stub(console, 'warn')
-      const exitMessage = 'Exit process when ghooks not being present'
-      // instead of really exiting the process ...
-      const exit = this.stub(process, 'exit', () => {
-        // ... throw a predetermined exception, thus preventing
-        // further code execution within the tested module ...
-        throw Error(exitMessage)
-      })
-      // ... and expect it to be eventually thrown
-      expect(() => {
-        proxyquire('../lib/hook.template.raw', stub)
-      }).to.throw(exitMessage)
+      proxyquire('../lib/hook.template.raw', stub)
       expect(warn).to.have.been.calledWithMatch(/ghooks not found!/i)
-      expect(exit).to.have.been.calledWith(1)
     }))
 
   })


### PR DESCRIPTION
By default, do not exit with an error if ghooks is not found.
This is to a) fix #70 and b) the preparation to introduce that behavior as optional.