### PR TITLE
Fail gracefully on occasional npm@2.15 hickups

### DIFF
--- a/bin/module-install
+++ b/bin/module-install
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+try {
+  const opt = require('opt-cli')
+  if (!opt.testOptOut('ghooks-install')) {
+    require('./install')
+  }
+} catch (e) {
+  console.warn( // eslint-disable-line no-console
+    '\nghooks postinstall could not be completed.\n' +
+    '==========================================\n\n' +
+    'Usually this is due to using npm@2.15.x. Please consider updating npm\n' +
+    'to its latest version or run the following command manually afterwards:\n\n' +
+    '\tnode ./bin/install\n'
+  )
+}

--- a/bin/module-install
+++ b/bin/module-install
@@ -10,6 +10,7 @@ try {
     '==========================================\n\n' +
     'Usually this is due to using npm@2.15.x. Please consider updating npm\n' +
     'to its latest version or run the following command manually afterwards:\n\n' +
-    '\tnode ./bin/install\n'
+    '\tnpm explore ghooks -- npm run install\n\n' +
+    'See https://github.com/gtramontina/ghooks/issues/71 for more information.\n'
   )
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "report-coverage": "cat ./coverage/lcov.info | node_modules/.bin/codecov",
     "validate": "npm t && npm run check-coverage",
     "commit": "git-cz",
-    "install": "opt --out ghooks-install --exec \"node ./bin/install\"",
+    "install": "node ./bin/module-install",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "dependencies": {


### PR DESCRIPTION
This should tackle #71 

What it does:
* Extracts the former npm `install` script into a separate one within `./bin` and calls **that** on `install`.
* Tries to use `opt-cli` as a library rather than as a cli tool and only invokes `ghooks` very own `./bin/install`, when `opt-cli` was found **and** the user has not opted-out of `ghooks-install`.
* Prints out the following warning if ghooks could not auto-run its installation script on `npm install`:

```
ghooks postinstall could not be completed.
==========================================

Usually this is due to using npm@2.15.x. Please consider updating npm
to its latest version or run the following command manually afterwards:

	node ./bin/install
```

An alternative to this could be to just run the install script and warn that a possible opt-out configuration could not be considered, but as that would require more work from the user to revert, than it would be to simply run `node ./bin/install` afterwards, I proposed this one here.

What do you guys think?

(A really dumbed down test project including Travis builds can be found [here](https://travis-ci.org/ta2edchimp/test-ghooks-on-npm-2.15), Node versions 0.10 and 0.12 are configured to use `npm@^2.0.0`).