### PR TITLE
Use spawn-cmd to fix spawning bug on windows

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,6 +1,6 @@
 const clone = require('lodash.clone')
 const managePath = require('manage-path')
-const spawn = require('spawn-command')
+const spawn = require('spawn-cmd').spawn
 const {resolve, basename} = require('path')
 const findup = require('findup')
 const fs = require('fs')

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "semantic-release": "^4.3.5",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.7.0",
+    "spawn-cmd": "0.0.2",
     "travis-after-all": "^1.4.4",
     "validate-commit-msg": "2.6.1"
   },


### PR DESCRIPTION
I was having an issue with an unhandled event error:
Error: spawn cmd.exe ENOENT

I think it's a windows issue with spawning processes, using spawn-cmd seems to make it work properly