### PR TITLE
Make it possible to configure an array of scripts per hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Add a `config.ghooks` entry in your `package.json` and simply specify which git 
 }
 ```
 
+Multiple commands per git hook are possible using arrays:
+
+```json
+{
+  "pre-commit": [ "check-something", "gulp lint" ],
+  …
+}
+
+```
+
+The commands are then executed in the order they're defined in `package.json`.
+
 **Note:** _The hooks' working directory is relative to the git root (where you have your `.git` directory). This means that if your package.json is in a subdirectory of your git repo, you'll need to cd into the directory before running any npm scripts. E.g.:_
 
 ```json

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -1,4 +1,6 @@
+const castArray = require('lodash.castarray')
 const clone = require('lodash.clone')
+const get = require('lodash.get')
 const managePath = require('manage-path')
 const spawn = require('spawn-command')
 const {resolve, basename} = require('path')
@@ -6,10 +8,8 @@ const findup = require('findup')
 const fs = require('fs')
 
 module.exports = function run(nodeModulesPath, filename, env) {
-  const command = commandFor(nodeModulesPath, hook(filename))
-  if (command) {
-    runCommand(command, env)
-  }
+  const commands = commandsFor(nodeModulesPath, hook(filename))
+  runCommands(commands, env)
 }
 
 function hook(filename) {
@@ -23,25 +23,23 @@ function replacePositionalVariables(command) {
   })
 }
 
-function commandFromPackage(packagePath, hookName) {
+function commandsFromPackage(packagePath, hookName) {
   const pkg = JSON.parse(fs.readFileSync(packagePath))
-  if (pkg.config && pkg.config.ghooks && pkg.config.ghooks[hookName]) {
-    return replacePositionalVariables(pkg.config.ghooks[hookName])
-  } else {
-    return null
-  }
+  const hookConfig = get(pkg, `config.ghooks.${hookName}`, [])
+  const filePaths = castArray(hookConfig)
+  return filePaths.map(filePath => replacePositionalVariables(filePath))
 }
 
-function commandFor(nodeModulesPath, hookName) {
+function commandsFor(nodeModulesPath, hookName) {
   const pkgFile = findup.sync(nodeModulesPath, 'package.json')
-  return commandFromPackage(resolve(pkgFile, 'package.json'), hookName)
+  return commandsFromPackage(resolve(pkgFile, 'package.json'), hookName)
 }
 
-function runCommand(command, env) {
+function runCommands(commands, env) {
   env = clone(env || process.env)
   const alterPath = managePath(env)
   alterPath.unshift(getNpmBin(process.cwd()))
-  spawn(command, {stdio: 'inherit', env}).on('exit', process.exit)
+  commands.forEach(command => spawn(command, {stdio: 'inherit', env}).on('exit', process.exit))
 }
 
 function getNpmBin(dirname) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "dependencies": {
     "execa": "^0.4.0",
     "findup": "0.1.5",
+    "lodash.castarray": "^4.4.0",
     "lodash.clone": "4.3.2",
+    "lodash.get": "^4.4.2",
     "manage-path": "2.0.0",
     "opt-cli": "1.5.1",
     "path-exists": "^2.0.0",

--- a/test/runner.test.js
+++ b/test/runner.test.js
@@ -30,6 +30,24 @@ describe('runner', function describeRunner() {
       .to.have.been.calledWithMatch('make pre-push', {stdio: 'inherit'})
   })
 
+  it('executes multiple commands specified on the ghooks config', () => {
+    setupPackageJsonWith({config: {
+      ghooks: {
+        'pre-commit': ['echo pre-commit one', 'echo pre-commit two'],
+        'pre-push': ['echo pre-push one', 'echo pre-push two'],
+      },
+    }})()
+    this.run(process.cwd(), '/pre-commit')
+    expect(this.spawn)
+      .to.have.been.calledWithMatch('echo pre-commit one', {stdio: 'inherit'})
+      .and.to.have.been.calledWithMatch('echo pre-commit two', {stdio: 'inherit'})
+
+    this.run(process.cwd(), '/pre-push')
+    expect(this.spawn)
+      .to.have.been.calledWithMatch('echo pre-push one', {stdio: 'inherit'})
+      .and.to.have.been.calledWithMatch('echo pre-push two', {stdio: 'inherit'})
+  })
+
   it('exits as the hook commands exits', () => {
     this.run(process.cwd(), '/pre-commit')
     expect(this.spawnOn).to


### PR DESCRIPTION
This way, you don't need a wrapper script to perform several checks for one
hook, e.g.:

    {
      ...
      "pre-commit": [
        "git-hooks/pre-commit/no_console_log",
        "gulp lint"
      ],
      ...
    }

The scripts are executed in the order that they're defined in package.json.

Configuring just one script remains possible:

    {
      ...
      "pre-commit": "gulp lint",
      ...
    }