### PR TITLE
docs(readme): update note about migrating to husky

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,16 @@ Feel free to reach out if you want to keep maintaining this project.
 
 ## Migrating to Husky
 
-To migrate from `ghooks` to `husky`, delete all of your git hooks first by deleting the `.git/hooks` directory (if you have any custom hooks, you should preserve those by deleting all other hooks individually). Then uninstall `ghooks` and install `husky`. Please refer to [this commit](https://github.com/nhsuk/connecting-to-services/commit/06e0d619de1fe7e90c287bcb95a5a7f20710a3ea) as an example.
+To migrate from `ghooks` to `husky`, uninstall `ghooks` and install `husky`:
+
+```sh
+npm uninstall ghooks --save-dev
+npm install husky --save-dev
+```
+
+`ghooks` scripts will be automatically migrated and custom hooks will be preserved.
+
+Please refer to [this commit](https://github.com/nhsuk/connecting-to-services/commit/06e0d619de1fe7e90c287bcb95a5a7f20710a3ea) as an example.
 
 # ghooks
 


### PR DESCRIPTION
Hi @gtramontina,

To simplify transition for bigger projects, I've updated husky to automatically migrate hooks that contain `// Generated by ghooks...`.

Migrating should now just be a matter of uninstalling ghooks and installing husky, here's an example:

```sh
$ npm install ghooks --save-dev && npm uninstall ghooks --save-dev
$ npm install husky --save-dev 

> husky@0.13.1 install /tmp/test/node_modules/husky
> node ./bin/install.js

husky
setting up hooks
migrating ghooks applypatch-msg script
migrating ghooks pre-applypatch script
...
```

Hope it will help :)